### PR TITLE
Use the default session when input textfield "joinSessionInput" is empty...

### DIFF
--- a/src/main/webapp/app/controller/Sessions.js
+++ b/src/main/webapp/app/controller/Sessions.js
@@ -40,6 +40,7 @@ Ext.define("ARSnova.controller.Sessions", {
 	},
 
 	login: function (options) {
+		console.debug("Controller: Sessions.login", options);
 		if (options.keyword.length !== 8) {
 			Ext.Msg.alert(Messages.NOTIFICATION, Messages.SESSION_ID_INVALID_LENGTH);
 			return;

--- a/src/main/webapp/app/controller/Sessions.js
+++ b/src/main/webapp/app/controller/Sessions.js
@@ -40,7 +40,6 @@ Ext.define("ARSnova.controller.Sessions", {
 	},
 
 	login: function (options) {
-		console.debug("Controller: Sessions.login", options);
 		if (options.keyword.length !== 8) {
 			Ext.Msg.alert(Messages.NOTIFICATION, Messages.SESSION_ID_INVALID_LENGTH);
 			return;

--- a/src/main/webapp/app/view/home/HomePanel.js
+++ b/src/main/webapp/app/view/home/HomePanel.js
@@ -103,7 +103,7 @@ Ext.define('ARSnova.view.home.HomePanel', {
 						xtype: 'input',
 						cls: 'joinSessionInput',
 						type: 'tel',
-						maxLength: 16,
+						maxLength: 16
 					},
 					name: 'keyword',
 					style: !!ARSnova.app.globalConfig.demoSessionKey ? 'margin-bottom: 5px' : '',

--- a/src/main/webapp/app/view/home/HomePanel.js
+++ b/src/main/webapp/app/view/home/HomePanel.js
@@ -103,7 +103,7 @@ Ext.define('ARSnova.view.home.HomePanel', {
 						xtype: 'input',
 						cls: 'joinSessionInput',
 						type: 'tel',
-						maxLength: 16
+						maxLength: 16,
 					},
 					name: 'keyword',
 					style: !!ARSnova.app.globalConfig.demoSessionKey ? 'margin-bottom: 5px' : '',
@@ -233,8 +233,18 @@ Ext.define('ARSnova.view.home.HomePanel', {
 		// delete the textfield-focus, to hide the numeric keypad on phones
 		this.down('textfield').blur();
 
+		/**
+		 * The global property "ARSnova.app.globalConfig.demoSessionKey" is always undefined.
+		 * Seems like a bug ?
+		 * So i have temporarily put this variable on here to avoid magic numbers.
+		 * This has to be changed later on !
+		 * - March, 5th/2005, m. schaefer -
+		 */
+		var _demoSessionKey = ARSnova.app.globalConfig.demoSessionKey || '71073692';
+
+		// console.log(ARSnova.app.globalConfig.demoSessionKey);
 		ARSnova.app.getController('Sessions').login({
-			keyword: this.down('textfield').getValue().replace(/ /g, ""),
+			keyword: this.down('textfield').getValue().replace(/ /g, "") || _demoSessionKey,
 			destroy: false,
 			panel: this
 		});

--- a/src/main/webapp/app/view/home/HomePanel.js
+++ b/src/main/webapp/app/view/home/HomePanel.js
@@ -242,7 +242,6 @@ Ext.define('ARSnova.view.home.HomePanel', {
 		 */
 		var _demoSessionKey = ARSnova.app.globalConfig.demoSessionKey || '71073692';
 
-		// console.log(ARSnova.app.globalConfig.demoSessionKey);
 		ARSnova.app.getController('Sessions').login({
 			keyword: this.down('textfield').getValue().replace(/ /g, "") || _demoSessionKey,
 			destroy: false,


### PR DESCRIPTION
....

This has been implemented due to a user review. The users has mentioned
that it would be easier to call the default session when no textinpunt is
given.

At the moment this implementation can be best seen as a (dirty) hack, because of a
bug or some pending changes by other developers which are not finished yet. The problem is that the
global property "ARSnova.app.globalConfig.demoSessionKey" returns undefined.

Hint:
According to that, the Label which shows an user the id for the default session
doesnt show up. But that is not in the scope of this pull request.