### PR TITLE
Changed the order of icons in feedback tab

### DIFF
--- a/src/main/webapp/app/view/feedback/StatisticPanel.js
+++ b/src/main/webapp/app/view/feedback/StatisticPanel.js
@@ -144,7 +144,7 @@ Ext.define('ARSnova.view.feedback.StatisticPanel', {
 		});
 
 		this.feedbackChartColors = [
-			'#f2a900', // thm-orange			
+			'#f2a900', // thm-orange
 			'#80ba24', // thm-green
 			'#971b2f', // thm-red
 			'#4a5c66'  // thm-grey

--- a/src/main/webapp/app/view/feedback/StatisticPanel.js
+++ b/src/main/webapp/app/view/feedback/StatisticPanel.js
@@ -79,17 +79,6 @@ Ext.define('ARSnova.view.feedback.StatisticPanel', {
 			items: [this.backButton]
 		});
 
-		this.feedbackOkButton = Ext.create('Ext.Panel', {
-			flex: 1,
-
-			items: [{
-				xtype: 'matrixbutton',
-				value: 'Kann folgen',
-				cls: 'feedbackStatisticButton voteButton feedbackOkBackground ' + buttonCls,
-				imageCls: 'icon-happy',
-				handler: this.buttonClicked
-			}]
-		});
 
 		this.feedbackGoodButton = Ext.create('Ext.Panel', {
 			cls: 'voteButtons',
@@ -103,6 +92,19 @@ Ext.define('ARSnova.view.feedback.StatisticPanel', {
 				handler: this.buttonClicked
 			}]
 		});
+
+		this.feedbackOkButton = Ext.create('Ext.Panel', {
+			flex: 1,
+
+			items: [{
+				xtype: 'matrixbutton',
+				value: 'Kann folgen',
+				cls: 'feedbackStatisticButton voteButton feedbackOkBackground ' + buttonCls,
+				imageCls: 'icon-happy',
+				handler: this.buttonClicked
+			}]
+		});
+
 
 		this.feedbackBadButton = Ext.create('Ext.Panel', {
 			cls: 'voteButtons',
@@ -134,16 +136,16 @@ Ext.define('ARSnova.view.feedback.StatisticPanel', {
 			docked: 'top',
 
 			items: [
-				this.feedbackOkButton,
 				this.feedbackGoodButton,
+				this.feedbackOkButton,
 				this.feedbackBadButton,
 				this.feedbackNoneButton
 			]
 		});
 
 		this.feedbackChartColors = [
+			'#f2a900', // thm-orange			
 			'#80ba24', // thm-green
-			'#f2a900', // thm-orange
 			'#971b2f', // thm-red
 			'#4a5c66'  // thm-grey
 		];
@@ -153,8 +155,8 @@ Ext.define('ARSnova.view.feedback.StatisticPanel', {
 			store: Ext.create('Ext.data.Store', {
 				fields: ['name', 'displayName', 'value', 'percent'],
 				data: [
-					{'name': 'Kann folgen', 'displayName': Messages.FEEDBACK_OKAY, 'value': 0, 'percent': 0.0},
 					{'name': 'Bitte schneller', 'displayName': Messages.FEEDBACK_GOOD, 'value': 0, 'percent': 0.0},
+					{'name': 'Kann folgen', 'displayName': Messages.FEEDBACK_OKAY, 'value': 0, 'percent': 0.0},
 					{'name': 'Zu schnell', 'displayName': Messages.FEEDBACK_BAD, 'value': 0, 'percent': 0.0},
 					{'name': 'Nicht mehr dabei', 'displayName': Messages.FEEDBACK_NONE, 'value': 0, 'percent': 0.0}
 				]
@@ -260,9 +262,6 @@ Ext.define('ARSnova.view.feedback.StatisticPanel', {
 		/* Swap values for "can follow" and "faster, please" feedback
 		 * TODO: improve implementation, this is a quick hack for MoodleMoot 2013 */
 		var values = feedbackValues.slice();
-		var tmpValue = values[0];
-		values[0] = values[1];
-		values[1] = tmpValue;
 
 		if (!Ext.isArray(values) || values.length !== store.getCount()) {
 			return;

--- a/src/main/webapp/app/view/feedback/VotePanel.js
+++ b/src/main/webapp/app/view/feedback/VotePanel.js
@@ -97,7 +97,7 @@ Ext.define('ARSnova.view.feedback.VotePanel', {
 					handler: function (button) {
 						ARSnova.app.getController('Feedback').vote({
 							value: button.config.value
-						});					
+						});
 					},
 					style: "margin-left:10px"
 				}

--- a/src/main/webapp/app/view/feedback/VotePanel.js
+++ b/src/main/webapp/app/view/feedback/VotePanel.js
@@ -77,18 +77,6 @@ Ext.define('ARSnova.view.feedback.VotePanel', {
 				{
 					xtype: 'matrixbutton',
 					buttonConfig: 'icon',
-					text: Messages.FEEDBACK_OKAY,
-					cls: 'noPadding noBackground voteButton feedbackOkBackground',
-					value: 'Kann folgen',
-					imageCls: 'icon-happy',
-					handler: function (button) {
-						ARSnova.app.getController('Feedback').vote({
-							value: button.config.value
-						});
-					}
-				}, {
-					xtype: 'matrixbutton',
-					buttonConfig: 'icon',
 					text: Messages.FEEDBACK_GOOD,
 					cls: 'noPadding noBackground voteButton feedbackGoodBackground',
 					value: 'Bitte schneller',
@@ -97,6 +85,19 @@ Ext.define('ARSnova.view.feedback.VotePanel', {
 						ARSnova.app.getController('Feedback').vote({
 							value: button.config.value
 						});
+					}
+				}, {
+					// changed button order
+					xtype: 'matrixbutton',
+					buttonConfig: 'icon',
+					text: Messages.FEEDBACK_OKAY,
+					cls: 'noPadding noBackground voteButton feedbackOkBackground',
+					value: 'Kann folgen',
+					imageCls: 'icon-happy',
+					handler: function (button) {
+						ARSnova.app.getController('Feedback').vote({
+							value: button.config.value
+						});					
 					},
 					style: "margin-left:10px"
 				}


### PR DESCRIPTION
During the usability test of ARSnova for the module "Web Engineering" we got some feedback for little tweaks. So I changed the order of the feedback icons to:
* Faster, Please!   (instead of: I can follow you.)
* I can follow you.  (instead of: Faster, Please!)
* Slower Please!
* You´ve lost me. 

![unbenannt](https://cloud.githubusercontent.com/assets/9314911/7494876/a3d2cba6-f40a-11e4-9bb9-f666a42c929f.PNG) ![new](https://cloud.githubusercontent.com/assets/9314911/7494870/9835c050-f40a-11e4-97fd-2089199a41ca.PNG)
