### PR TITLE
[Tweak]: added descripitve note for required field

### DIFF
--- a/src/main/webapp/app/internationalization.js
+++ b/src/main/webapp/app/internationalization.js
@@ -300,7 +300,7 @@
 				CATEGORY_PLACEHOLDER: "Thema eingeben",
 				ABSTENTION: 'Enthaltung',
 				ABSTENTIONS: 'Enthaltungen',
-				ABSTENTION_POSSIBLE: 'Enthaltung möglich?',
+				ABSTENTION_POSSIBLE: 'Enthaltung möglich? <i>(Pflichtangabe)</i>',
 				MY_COURSES: "Meine Kurse:",
 				NO_COURSES_FOUND: "Es konnten keine Kurse gesucht werden.",
 				CORRECT_ANSWER: 'Richtige Antwort',

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -38,4 +38,5 @@
 			</div>
 		</noscript>
 	</body>
+	<!-- just a test comment -->
 </html>


### PR DESCRIPTION
A usability test showed, that users were not able to identify whether certain inputs and/or specifications were required or not. Hence a note was added to a label to help the user identify required inputs.