### PR TITLE
fix session info editing without publicPool

### DIFF
--- a/src/main/webapp/app/model/Session.js
+++ b/src/main/webapp/app/model/Session.js
@@ -51,9 +51,25 @@ Ext.define('ARSnova.model.Session', {
 
 		validations: [
 			{type: 'presence', field: 'type'},
-			{type: 'presence', field: 'name', min: 1, max: 50},
-			{type: 'length', field: 'shortName', min: 1, max: 12},
-			{type: 'presence', field: 'creator'}
+			{
+				type: 'presence',
+				field: 'name',
+				min: 1,
+				max: 50,
+				message: Messages.SESSION_NAME + ':\t' + Messages.SESSIONPOOL_NOTIFICATION_SESSION_NAME
+			},
+			{
+				type: 'length',
+				field: 'shortName',
+				min: 1,
+				max: 12,
+				message: Messages.SESSION_SHORT_NAME + ':\t' + Messages.SESSIONPOOL_NOTIFICATION_SESSION_SHORTNAME
+			},
+			{
+				type: 'presence',
+				field: 'creator',
+				message: Messages.EXPORT_FIELD_NAME + ':\t' + Messages.SESSIONPOOL_NOTIFICATION_NAME
+			}
 		],
 
 		learningProgress: {

--- a/src/main/webapp/app/view/home/SessionInfoPanel.js
+++ b/src/main/webapp/app/view/home/SessionInfoPanel.js
@@ -384,18 +384,33 @@ Ext.define('ARSnova.view.home.SessionInfoPanel', {
 	validate: function () {
 		var isValid = true;
 		var me = this ;
-		var validation = Ext.create('ARSnova.model.PublicPool', {
-			name: me.creatorName.getValue(),
-			hs: me.university.getValue(),
-			subject: me.subject.getValue(),
-			licence: me.licence.getValue(),
-			level: me.level.getValue(),
-			email: me.email.getValue(),
-			sessionName: me.sessionName.getValue(),
-			sessionShortName: me.sessionShortName.getValue(),
-			description: me.description.getValue(),
-			faculty: me.faculty.getValue()
-		});
+		var config = ARSnova.app.globalConfig;
+		var validation;
+		if (config.features.publicPool) {
+			validation = Ext.create('ARSnova.model.PublicPool', {
+				name: me.creatorName.getValue(),
+				hs: me.university.getValue(),
+				subject: me.subject.getValue(),
+				licence: me.licence.getValue(),
+				level: me.level.getValue(),
+				email: me.email.getValue(),
+				sessionName: me.sessionName.getValue(),
+				sessionShortName: me.sessionShortName.getValue(),
+				description: me.description.getValue(),
+				faculty: me.faculty.getValue()
+			});
+		} else {
+			validation = Ext.create('ARSnova.model.Session', {
+				type: 'session',
+				name: me.sessionName.getValue(),
+				shortName: me.sessionShortName.getValue(),
+				ppUniversity: me.university.getValue(),
+				creator: me.creatorName.getValue(),
+				ppAuthorMail: me.email.getValue(),
+				ppDescription: me.description.getValue(),
+				ppFaculty: me.faculty.getValue()
+			});
+		}
 
 		var errs = validation.validate();
 		var msg = '';


### PR DESCRIPTION
when the publicPool is disabled, the validation of the session info fails as fields like subject or licence are missing.

This fix does use the Session Model to do the validation when the publicPool is disabled and also adds validation messages from the publicPool Model.