### PR TITLE
when deleting a session, do not call loadCreatedSessions twice

### DIFF
--- a/src/main/webapp/app/view/speaker/InClass.js
+++ b/src/main/webapp/app/view/speaker/InClass.js
@@ -243,9 +243,6 @@ Ext.define('ARSnova.view.speaker.InClass', {
 						ARSnova.app.showLoadIndicator(Messages.LOAD_MASK_SESSION_DELETE);
 						ARSnova.app.sessionModel.destroy(sessionStorage.getItem('keyword'), {
 							success: function () {
-								ARSnova.app.mainTabPanel.tabPanel.on('activeitemchange', function () {
-									ARSnova.app.mainTabPanel.tabPanel.homeTabPanel.mySessionsPanel.loadCreatedSessions();
-								}, this, {single: true});
 								ARSnova.app.getController('Sessions').logout();
 							},
 							failure: function (response) {


### PR DESCRIPTION
the loadCreatedSessions is called anyway on the transition to the sessions view, calling it twice results in duplicate entries as the entries from the first call in the createdSessionsObject are not removed on the second and updatePagination concats.