### PR TITLE
Disable session create button when no feature selection was made

### DIFF
--- a/src/main/webapp/app/view/diagnosis/AddOnsPanel.js
+++ b/src/main/webapp/app/view/diagnosis/AddOnsPanel.js
@@ -84,6 +84,8 @@ Ext.define('ARSnova.view.diagnosis.AddOnsPanel', {
 				selectionChange: function (field) {
 					var selections = this.getValues();
 					me.optionalFieldSet.setHidden(!selections.lecture && !selections.jitt);
+					me.submitButton.setDisabled(!selections.lecture && !selections.interposed
+						&& !selections.jitt && !selections.feedback);
 				}
 			},
 


### PR DESCRIPTION
During session creation the "create session" button should be disabled until a feature selection was made by the user. This is less intrusive than showing an error to the user because he did not make any selections.