### PR TITLE
Changed the word "gesucht" to "gefunden" because when NO_COURSES_FOUN…

### DIFF
--- a/src/main/webapp/app/internationalization.js
+++ b/src/main/webapp/app/internationalization.js
@@ -325,7 +325,7 @@
 				ABSTENTIONS: 'Enthaltungen',
 				ABSTENTION_POSSIBLE: 'Enthaltung möglich?',
 				MY_COURSES: "Meine Kurse:",
-				NO_COURSES_FOUND: "Es konnten keine Kurse gesucht werden.",
+				NO_COURSES_FOUND: "Es konnten keine Kurse gefunden werden.",
 				CORRECT_ANSWER: 'Richtige Antwort',
 				YES: "Ja",
 				NO: "Nein",


### PR DESCRIPTION
…D is used the program was searching. It was not able to find a course. So the new translation is better in this context.