### PR TITLE
Changed export button text to find pool export faster

### DIFF
--- a/src/main/webapp/app/internationalization.js
+++ b/src/main/webapp/app/internationalization.js
@@ -124,6 +124,7 @@
 				SESSION_SAVE: "Session anlegen",
 				SESSION_OPTIONAL_INFO: "Optionale Informationen",
 				SAVE: 'Speichern',
+				EXPORT: '(Pool) Export',
 
 				/* feedback */
 				FEEDBACK: "Feedback",
@@ -741,6 +742,7 @@
 				SESSION_SAVE: "Create Session",
 				SESSION_OPTIONAL_INFO: "Optional Information",
 				SAVE: 'Save',
+				EXPORT: '(Pool) Export',
 
 				/* feedback */
 				FEEDBACK: "Feedback",

--- a/src/main/webapp/app/view/home/MySessionsPanel.js
+++ b/src/main/webapp/app/view/home/MySessionsPanel.js
@@ -266,7 +266,7 @@ Ext.define('ARSnova.view.home.MySessionsPanel', {
 			this.importButtonPanel.add(this.importButton);
 
 			this.exportButton = Ext.create('ARSnova.view.MatrixButton', {
-				text: 'Export',
+				text: Messages.EXPORT,
 				buttonConfig: 'icon',
 				imageCls: 'icon-cloud-download ',
 				scope: this,


### PR DESCRIPTION
When you are a new ARSnova user, it is hard to find the Pool export option. It is hidden under "Export", so I've changed the button text to "(Pool) Export".