### PR TITLE
Changed "University" to "Institution" in Session Info

### DIFF
--- a/src/main/webapp/app/internationalization.js
+++ b/src/main/webapp/app/internationalization.js
@@ -1040,7 +1040,7 @@
 				EXPORT_BUTTON_LABEL: "Export",
 				EXPORT_SESSION_TO_PUBLIC_TITLE: "Public Pool Export",
 				EXPORT_FIELD_NAME: "Name of teacher",
-				EXPORT_FIELD_UNI: "University",
+				EXPORT_FIELD_UNI: "Institution",
 				EXPORT_FIELD_LOGO: "Logo",
 				EXPORT_FIELD_SUBJECT: "Course of studies",
 				EXPORT_FIELD_LICENCE: "License",


### PR DESCRIPTION
In a lot of english speaking countries, e.g. America, Ireland, there are no universities. Those higher level institutions are being called "colleges" there.
To make the session info more general I renamed "University" to "Institution".