### PR TITLE
Feature: Add "comment" badge button to speaker utilities in showcase panel

### DIFF
--- a/src/main/webapp/app/controller/Questions.js
+++ b/src/main/webapp/app/controller/Questions.js
@@ -446,6 +446,7 @@ Ext.define("ARSnova.controller.Questions", {
 		var mainTabPanel = ARSnova.app.mainTabPanel;
 		var tP = mainTabPanel.tabPanel;
 		var panel = tP.userQuestionsPanel || tP.speakerTabPanel;
+		var hideOverlay = true;
 
 		if (tP.getActiveItem() === tP.speakerTabPanel) {
 			var showcasePanel = panel.showcaseQuestionPanel;
@@ -453,7 +454,10 @@ Ext.define("ARSnova.controller.Questions", {
 			if (tP.speakerTabPanel.getActiveItem() === showcasePanel) {
 				if (showcasePanel.getActiveItem().getItemId() === id) {
 					if (showcasePanel.getActiveItem().questionObj.questionType === 'slide') {
+						hideOverlay = !parseInt(answerCount) || !ARSnova.app.projectorModeActive;
 						showcasePanel.toolbar.setAnswerCounter(answerCount, Messages.COMMENT);
+						showcasePanel.speakerUtilities.commentOverlay.setBadgeText(answerCount);
+						showcasePanel.speakerUtilities.commentOverlay.setHidden(hideOverlay);
 					} else if (!answerCount && abstentionCount) {
 						showcasePanel.toolbar.setAnswerCounter(abstentionCount, Messages.ABSTENTION);
 					} else {

--- a/src/main/webapp/app/view/FreetextAnswerPanel.js
+++ b/src/main/webapp/app/view/FreetextAnswerPanel.js
@@ -88,10 +88,10 @@ Ext.define('ARSnova.view.FreetextAnswerPanel', {
 
 				ARSnova.app.innerScrollPanel = false;
 				ARSnova.app.taskManager.stop(me.checkFreetextAnswersTask);
-				me.speakerUtilities.initializeZoomComponents();
 
 				if (ARSnova.app.userRole === ARSnova.app.USER_ROLE_SPEAKER) {
 					object = speakerTabPanel.statisticTabPanel.roundManagementPanel.editButtons.questionObj;
+					me.speakerUtilities.initializeZoomComponents();
 
 					switch (speakerTabPanel.getActiveItem()) {
 						case speakerTabPanel.showcaseQuestionPanel:

--- a/src/main/webapp/app/view/FreetextDetailAnswer.js
+++ b/src/main/webapp/app/view/FreetextDetailAnswer.js
@@ -176,20 +176,19 @@ Ext.define('ARSnova.view.FreetextDetailAnswer', {
 						}
 
 						self.sTP.items.items.pop(); // Remove this panel from view stack
-						self.sTP.animateActiveItem(
-							self.sTP.items.items[self.sTP.items.items.length - 1], // Switch back to top of view stack
-							{
-								type: 'slide',
-								direction: 'right',
-								duration: 700,
-								scope: this,
-								listeners: {
-									animationend: function () {
-										self.destroy();
-									}
+						var prevTabPanel = self.sTP.items.items[self.sTP.items.items.length - 1];
+						self.sTP.animateActiveItem(prevTabPanel, { // Switch back to top of view stack
+							type: 'slide',
+							direction: 'right',
+							duration: 700,
+							scope: this,
+							listeners: {
+								animationend: function () {
+									self.destroy();
+									prevTabPanel.getActiveItem().checkFreetextAnswersTask.taskRunTime = 0;
 								}
 							}
-						);
+						});
 					},
 					failure: function () {
 						console.log('server-side error: deletion of freetext answer failed');
@@ -213,7 +212,9 @@ Ext.define('ARSnova.view.FreetextDetailAnswer', {
 
 		this.on('painted', function () {
 			ARSnova.app.innerScrollPanel = this;
-			this.speakerUtilities.setProjectorMode(this, ARSnova.app.projectorModeActive);
+			if (ARSnova.app.userRole === ARSnova.app.USER_ROLE_SPEAKER) {
+				this.speakerUtilities.setProjectorMode(this, ARSnova.app.projectorModeActive);
+			}
 		});
 
 		this.on('activate', function () {

--- a/src/main/webapp/app/view/FreetextQuestion.js
+++ b/src/main/webapp/app/view/FreetextQuestion.js
@@ -262,10 +262,6 @@ Ext.define('ARSnova.view.FreetextQuestion', {
 				this.disableQuestion(false);
 			}
 
-			if (this.viewOnly) {
-				this.setAnswerCount();
-			}
-
 			if (ARSnova.app.userRole === ARSnova.app.USER_ROLE_SPEAKER && this.editButtons) {
 				this.editButtons.changeHiddenState();
 			}
@@ -352,7 +348,10 @@ Ext.define('ARSnova.view.FreetextQuestion', {
 					abstentionCount = parseInt(numAnswers[1]);
 
 				if (me.questionObj.questionType === 'slide') {
+					var hideOverlay = !parseInt(answerCount) || !ARSnova.app.projectorModeActive;
 					sTP.showcaseQuestionPanel.toolbar.setAnswerCounter(answerCount, Messages.COMMENT);
+					sTP.showcaseQuestionPanel.speakerUtilities.commentOverlay.setBadgeText(answerCount);
+					sTP.showcaseQuestionPanel.speakerUtilities.commentOverlay.setHidden(hideOverlay);
 				} else if (!answerCount && abstentionCount) {
 					sTP.showcaseQuestionPanel.toolbar.setAnswerCounter(abstentionCount, Messages.ABSTENTION);
 				} else {

--- a/src/main/webapp/app/view/speaker/InClass.js
+++ b/src/main/webapp/app/view/speaker/InClass.js
@@ -144,7 +144,7 @@ Ext.define('ARSnova.view.speaker.InClass', {
 			text: Messages.CHANGE_ROLE_BUTTONTEXT,
 			cls: 'smallerActionButton',
 			buttonConfig: 'icon',
-			imageCls: 'icon-speaker',
+			imageCls: 'icon-users',
 			handler: function () {
 				ARSnova.app.getController('Sessions').changeRole();
 			}

--- a/src/main/webapp/app/view/speaker/ShowcaseQuestionPanel.js
+++ b/src/main/webapp/app/view/speaker/ShowcaseQuestionPanel.js
@@ -149,6 +149,7 @@ Ext.define('ARSnova.view.speaker.ShowcaseQuestionPanel', {
 
 	onPainted: function () {
 		this.updateEditButtons();
+		this.getActiveItem().setAnswerCount();
 	},
 
 	onItemChange: function (panel, newQuestion, oldQuestion) {
@@ -165,6 +166,11 @@ Ext.define('ARSnova.view.speaker.ShowcaseQuestionPanel', {
 				newQuestion.setPadding('0 0 50 0');
 			}
 
+			if (newQuestion.questionObj.questionType !== 'slide') {
+				panel.speakerUtilities.commentOverlay.setHidden(true);
+			}
+
+			panel.getActiveItem().setAnswerCount();
 			panel.updateControlButtonHiddenState();
 			panel.speakerUtilities.setHidden(screenWidth < 700);
 			panel.speakerUtilities.checkQuestionType(newQuestion);

--- a/src/main/webapp/app/view/speaker/SpeakerUtilities.js
+++ b/src/main/webapp/app/view/speaker/SpeakerUtilities.js
@@ -79,6 +79,24 @@ Ext.define('ARSnova.view.speaker.SpeakerUtilities', {
 			hidden: true
 		});
 
+		this.commentOverlay = Ext.create('Ext.Button', {
+			ui: 'action',
+			docked: 'bottom',
+			cls: 'commentOverlay',
+			badgeText: '0',
+			badgeCls: 'badgeicon',
+			iconCls: 'icon-comment',
+			callFn: ARSnova.app.getController('Questions').listFeedbackQuestions,
+			handler: function () {
+				var activeItem = me.getParent().getActiveItem();
+				var questionObj = activeItem.questionObj;
+				if (questionObj && questionObj.questionType === 'slide') {
+					ARSnova.app.getController('Statistics').prepareStatistics(activeItem);
+				}
+			},
+			hidden: true
+		});
+
 		this.projectorButton = Ext.create('Ext.Button', {
 			ui: 'action',
 			docked: 'bottom',
@@ -146,6 +164,7 @@ Ext.define('ARSnova.view.speaker.SpeakerUtilities', {
 		this.add([
 			this.interposedOverlay,
 			this.feedbackOverlay,
+			this.commentOverlay,
 			this.hideShowcaseControlButton,
 			this.projectorButton,
 			this.zoomButton

--- a/src/main/webapp/app/view/user/InClass.js
+++ b/src/main/webapp/app/view/user/InClass.js
@@ -110,7 +110,7 @@ Ext.define('ARSnova.view.user.InClass', {
 		this.roleIconButton = Ext.create('ARSnova.view.MatrixButton', {
 			text: Messages.CHANGE_ROLE_BUTTONTEXT,
 			buttonConfig: 'icon',
-			imageCls: 'icon-users',
+			imageCls: 'icon-speaker',
 			hidden: !ARSnova.app.isSessionOwner,
 			controller: 'Sessions',
 			action: 'changeRole',

--- a/src/main/webapp/resources/sass/_theme.scss
+++ b/src/main/webapp/resources/sass/_theme.scss
@@ -101,6 +101,8 @@ $icon-release-timer-color: $button-icon-alternative-color;
 $icon-lock-unlocked-color: $button-icon-color;
 $icon-lock-locked-color: $brand-danger;
 $icon-chart-color: $button-icon-alternative-color;
+$icon-comment-color: $default-white-color;
+$icon-comment-border-color: $brand-warning;
 $icon-bullhorn-color: $brand-warning;
 $icon-presenter-color: $brand-primary;
 $icon-hint-color: $brand-warning;

--- a/src/main/webapp/resources/sass/app/components/_speakerUtils.scss
+++ b/src/main/webapp/resources/sass/app/components/_speakerUtils.scss
@@ -74,9 +74,25 @@
 			color: $icon-questionmark-color;
 
 			&:before {
-				font-size: 96px;
+				font-size: 80px;
 				top: -20px;
 				left: -8px;
+			}
+		}
+	}
+
+	&.commentOverlay {	
+		.x-button-icon {
+			color: $icon-comment-color;
+			text-shadow: 2px 2px 1px $icon-comment-border-color,
+				2px -2px 1px $icon-comment-border-color,
+				-2px 2px 1px $icon-comment-border-color,
+				-2px -2px 1px $icon-comment-border-color;
+		    margin-bottom: 30px;
+		    left: 1px;
+
+			&:before {
+				font-size: 76px;
 			}
 		}
 	}
@@ -106,7 +122,8 @@
 	}
 	
 	&.interposedOverlay,
-	&.feedbackOverlay {
+	&.feedbackOverlay,
+	&.commentOverlay {
 		width: 100px;
 		height: 100px;
 		display: flex;


### PR DESCRIPTION
**Changes:**
- Adds an additional button to speaker-utilities in showcase panel. This button is only visible for (keynote) slides and in projector-mode
- Improve answer count retrieval after entering and getting back to showcase panel
- Switch icons for role-change buttons (student & speaker)

**Bugfixes:**
- Remove freetext answers instantly from list after deletion
- Fix some reference errors

**Added theme options:**
- $icon-comment-color: $default-white-color;  // comment button background color
- $icon-comment-border-color: $brand-warning; // comment button border (text-shadow) color

<img width="1440" alt="showcase-utitlities" src="https://cloud.githubusercontent.com/assets/5627724/17249330/d1db9c60-559f-11e6-9f74-e24c5741757d.png">
