### PR TITLE
Show user his course sessions he has not yet visited or did not create

### DIFF
--- a/src/main/webapp/app/model/Course.js
+++ b/src/main/webapp/app/model/Course.js
@@ -30,7 +30,7 @@ Ext.define('ARSnova.model.Course', {
 		]
 	},
 
-	getMyCourses: function (callbacks, sortby) {
-		return this.getProxy().getMyCourses(callbacks, sortby);
+	getMyCourses: function (callbacks, sortby, onlyTeacher) {
+		return this.getProxy().getMyCourses(callbacks, sortby, onlyTeacher);
 	}
 });

--- a/src/main/webapp/app/model/Session.js
+++ b/src/main/webapp/app/model/Session.js
@@ -165,6 +165,10 @@ Ext.define('ARSnova.model.Session', {
 		return this.getProxy().getMyPublicPoolSessions(callbacks, offset, limit);
 	},
 
+	getSessionsForCourses: function (offset, limit, courses, callbacks) {
+		return this.getProxy().getSessionsForCourses(callbacks, courses, offset, limit);
+	},
+
 	getMyVisitedSessions: function (offset, limit, callbacks, sortby) {
 		return this.getProxy().getMyVisitedSessions(callbacks, sortby, offset, limit);
 	},

--- a/src/main/webapp/app/proxy/RestProxy.js
+++ b/src/main/webapp/app/proxy/RestProxy.js
@@ -168,6 +168,32 @@ Ext.define('ARSnova.proxy.RestProxy', {
 		});
 	},
 
+	getSessionsForCourses: function (callbacks, courses, offset, limit) {
+		this.arsjax.request({
+			url: "session/relevantFromCourse",
+			method: "GET",
+
+			params: {
+				courses: courses
+			},
+			headers: {
+				Range: this.constructRangeString(offset, limit)
+			},
+			success: function (response) {
+				if (response.status === 204) {
+					callbacks.success.call(this, []);
+				} else {
+					callbacks.success.call(this, Ext.decode(response.responseText));
+				}
+			},
+			204: callbacks.empty,
+
+			401: callbacks.unauthenticated,
+			404: callbacks.notFound,
+			failure: callbacks.failure
+		});
+	},
+
 	getPublicPoolSessions: function (callbacks) {
 		this.arsjax.request({
 			url: "session/publicpool",
@@ -267,12 +293,13 @@ Ext.define('ARSnova.proxy.RestProxy', {
 	 * @return session-objects, if found
 	 * @return false, if nothing found
 	 */
-	getMyCourses: function (callbacks, sortby) {
+	getMyCourses: function (callbacks, sortby, onlyTeacher) {
 		this.arsjax.request({
 			url: "mycourses",
 			method: "GET",
 			params: {
-				sortby: sortby
+				sortby: sortby,
+				onlyTeacher: onlyTeacher
 			},
 			success: callbacks.success,
 			failure: function (response) {

--- a/src/main/webapp/app/view/home/HomePanel.js
+++ b/src/main/webapp/app/view/home/HomePanel.js
@@ -255,6 +255,7 @@ Ext.define('ARSnova.view.home.HomePanel', {
 		this.on('resize', function () {
 			this.resizeSessionButtons();
 			this.resizeLastVisitedSessionButtons();
+			this.resizeCourseSessionsButtons();
 		});
 	},
 

--- a/src/main/webapp/app/view/home/HomePanel.js
+++ b/src/main/webapp/app/view/home/HomePanel.js
@@ -469,33 +469,40 @@ Ext.define('ARSnova.view.home.HomePanel', {
 
 		ARSnova.app.courseModel.getMyCourses({
 			success: Ext.bind(function (response) {
-				var courseIds = [];
-				var courses = Ext.decode(response.responseText);
-				courses.forEach(function addElemen(element, index, array) {
-					courseIds.push(parseInt(element.id));
-				});
-				ARSnova.app.sessionModel.getSessionsForCourses(
-					me.courseSessionsObject.getStartIndex(),
-					me.courseSessionsObject.offset,
-					courseIds, {
-						success: function (sessions) {
-							me.displaySessions(
-								sessions, me.myCourseSessionsForm, me.courseSessionsObject, hideLoadingMask,
-								me.loadCourseSessions
-								);
-							me.resizeCourseSessionsButtons();
-							if (sessions.length > 0) {
-								promise.resolve(sessions);
-							} else {
+				if (response.responseText === "[]") {
+					hideLoadingMask();
+					me.myCourseSessionsForm.hide();
+					promise.reject();
+				} else {
+					var courseIds = [];
+					var courses = Ext.decode(response.responseText);
+					courses.forEach(function addElemen(element, index, array) {
+						courseIds.push(parseInt(element.id));
+					});
+					ARSnova.app.sessionModel.getSessionsForCourses(
+						me.courseSessionsObject.getStartIndex(),
+						me.courseSessionsObject.offset,
+						courseIds, {
+							success: function (sessions) {
+								me.displaySessions(
+									sessions, me.myCourseSessionsForm, me.courseSessionsObject, hideLoadingMask,
+									me.loadCourseSessions
+									);
+								me.resizeCourseSessionsButtons();
+								if (sessions.length > 0) {
+									promise.resolve(sessions);
+								} else {
+									promise.reject();
+								}
+							},
+							empty: function () {
+								hideLoadingMask();
+								me.myCourseSessionsForm.hide();
 								promise.reject();
 							}
-						},
-						empty: function () {
-							hideLoadingMask();
-							me.myCourseSessionsForm.hide();
-							promise.reject();
 						}
-					});
+					);
+				}
 			}, this),
 			empty: function () {
 				hideLoadingMask();

--- a/src/main/webapp/app/view/home/NewSessionPanel.js
+++ b/src/main/webapp/app/view/home/NewSessionPanel.js
@@ -273,6 +273,6 @@ Ext.define('ARSnova.view.home.NewSessionPanel', {
 			failure: function () {
 				console.log("my courses request failure");
 			}
-		}, (window.innerWidth > 321 ? 'name' : 'shortname'));
+		}, (window.innerWidth > 321 ? 'name' : 'shortname'), true);
 	}
 });


### PR DESCRIPTION
I thought that this feature already existed, however neither could I get it to work nor could I find anything about it in the codebase, therefore I (re)implemented it.
This PR, along with the other one (https://github.com/thm-projects/arsnova-backend/pull/39) implements a feature that shows the user those sessions that were created for a LMS course and which he has not yet visitited or did not create himself.
When he logs in there will be another list for those sessions below the visited sessions list, so there is no need anymore to enter the session id. When he joins a session in that way this session will be one of his visited sessions and therefore won't appear in the new session list anymore.