### PR TITLE
Fixed error in LearningProgressPanel

### DIFF
--- a/src/main/webapp/app/view/LearningProgressPanel.js
+++ b/src/main/webapp/app/view/LearningProgressPanel.js
@@ -230,7 +230,7 @@ Ext.define('ARSnova.view.LearningProgressPanel', {
 			var max = 2500;
 			this.learningProgressChange = Ext.Function.createBuffered(function () {
 				// Reset run-time to enforce reload of learning progress
-				this.courseLearningProgressTask.taskRunTime = 0;
+				this.checkLearningProgressTask.taskRunTime = 0;
 			}, Math.random() * (max - min) + min, this);
 		}
 	},


### PR DESCRIPTION
It seems that this is just a copy/paste error from InClass.js where the timer is called courseLearningProgressTask whereas in LearningProgressPanel it is called checkLearningProgressTask.