### PR TITLE
Edit lms state of session

### DIFF
--- a/src/main/webapp/app/controller/Sessions.js
+++ b/src/main/webapp/app/controller/Sessions.js
@@ -361,6 +361,17 @@ Ext.define("ARSnova.controller.Sessions", {
 		activePanel.animateActiveItem(useCasePanel, 'slide');
 	},
 
+	loadLmsOptions: function (options) {
+		var activePanel = ARSnova.app.mainTabPanel.tabPanel.getActiveItem();
+		var lmsOptionsPanel = Ext.create('ARSnova.view.diagnosis.LmsOptionsPanel', {
+			options: options,
+			sessionInfo: options.sessionInfo
+		});
+
+		activePanel.animateActiveItem(lmsOptionsPanel, 'slide');
+		lmsOptionsPanel.onShow();
+	},
+
 	validateSessionOptions: function (options) {
 		var session = ARSnova.app.sessionModel;
 

--- a/src/main/webapp/app/internationalization.js
+++ b/src/main/webapp/app/internationalization.js
@@ -690,6 +690,7 @@
 				SORT_REVERT: "Änderung<br/>verwerfen",
 				CHANGE_FEATURES: "Use Case<br/>wechseln",
 				CHANGE_ROLE_BUTTONTEXT: "Rolle<br/>wechseln",
+				CHANGE_LMS_OPTIONS: "Kurs<br/>ändern",
 
 				NEW_SLIDE: "Folien<br/>erstellen",
 				NEW_CONTENT: "Inhalte<br/>erstellen",
@@ -782,6 +783,11 @@
 				USECASE_ARSNOVA_CUSTOM_DETAILS: "###Eigene Funktions- und Formatauswahl\n\n Sie können die Funktionalität Ihrer Session kombinieren aus: \n- Hörsaalfragen (alle Formate) \n- Vorbereitungsaufgaben (alle Formate)\n- Fragen & Kommentare der Studierenden\n- Live Feedback\n- Vortragsfolien\n- 2-Runden-Abstimmungen\n- Lernstandsberechnung",
 
 				TWITTER_WALL_PRIVACY_INFO: "Hinweis: Die Lehrperson kann Ihre Fragen und Kommentare auf der Twitter Wall anzeigen.",
+
+				/*Lms options*/
+				LMS_OPTIONS: "LMS  Optionen",
+				LMS_ENABLE_TEXT: "Session an LMS-Kurs anbinden",
+				LMS_SELECT_COURSE: "Kurs wählen",
 
 				/* errors */
 				SESSION_NOT_FOUND: "Diese Session gibt es nicht",
@@ -1571,6 +1577,7 @@
 				SORT_REVERT: "Revert<br/>changes",
 				CHANGE_FEATURES: "Change<br/>use case",
 				CHANGE_ROLE_BUTTONTEXT: "Change<br/>role",
+				CHANGE_LMS_OPTIONS: "Change<br/>course",
 
 				NEW_SLIDE: "Create new<br/>slides",
 				NEW_CONTENT: "Create new<br/>content",
@@ -1663,6 +1670,11 @@
 				USECASE_ARSNOVA_CUSTOM_DETAILS: "###My ARSnova\n\n Personal selection of didactic functions...",
 
 				TWITTER_WALL_PRIVACY_INFO: "In current session mode, the teacher is able to show your question on the Twitter Wall.",
+
+				/*Lms options*/
+				LMS_OPTIONS: "LMS  Options",
+				LMS_ENABLE_TEXT: "Link session to LMS course",
+				LMS_SELECT_COURSE: "Select course",
 
 				/* errors */
 				SESSION_NOT_FOUND: "This session does not seem to exist.",

--- a/src/main/webapp/app/view/diagnosis/LmsOptionsPanel.js
+++ b/src/main/webapp/app/view/diagnosis/LmsOptionsPanel.js
@@ -1,0 +1,189 @@
+/*
+ * This file is part of ARSnova Mobile.
+ * Copyright (C) 2011-2012 Christian Thomas Weber
+ * Copyright (C) 2012-2017 The ARSnova Team
+ *
+ * ARSnova Mobile is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ARSnova Mobile is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ARSnova Mobile.  If not, see <http://www.gnu.org/licenses/>.
+ */
+Ext.define('ARSnova.view.diagnosis.LmsOptionsPanel', {
+	extend: 'Ext.Container',
+
+	config: {
+		options: {},
+		sessionInfo: {},
+		fullscreen: true,
+		title: 'LmsOptionsPanel',
+		scrollable: {
+			direction: 'vertical',
+			directionLock: true
+		},
+		layout: {
+			type: 'vbox',
+			pack: 'center'
+		}
+	},
+
+	courseSelect: null,
+	courses: null,
+	course: null,
+
+	initialize: function () {
+		this.callParent(arguments);
+		var me = this;
+
+		this.backButton = Ext.create('Ext.Button', {
+			text: Messages.BACK,
+			ui: 'back',
+			scope: this,
+			handler: this.transitionBackToInClassPanel
+		});
+
+		this.toolbar = Ext.create('Ext.TitleBar', {
+			title: Messages.LMS_OPTIONS,
+			docked: 'top',
+			ui: 'light',
+			items: [this.backButton]
+		});
+
+
+		this.submitButton = Ext.create('Ext.Button', {
+			cls: 'saveButton centered',
+			ui: 'confirm',
+			text: Messages.SAVE,
+			scope: this,
+			handler: function () {
+				var sessionInfo = me.getSessionInfo();
+				if (me.course === null) {
+					sessionInfo.courseType = null;
+					sessionInfo.courseId = null;
+					sessionInfo.courseSession = false;
+				} else {
+					sessionInfo.courseType = me.course.type;
+					sessionInfo.courseId = me.course.id;
+					sessionInfo.courseSession = true;
+				}
+				ARSnova.app.getController('Sessions').update(sessionInfo);
+				me.transitionBackToInClassPanel();
+			}
+		});
+
+		this.courseSelect = Ext.create('Ext.field.Select', {
+			label: Messages.LMS_SELECT_COURSE,
+			placeHolder: 'Course',
+			hidden: this.getSessionInfo().courseType === null,
+			listeners: {
+				change: function (field, newValue) {
+					me.course = me.courses[newValue];
+				}
+			}
+		});
+
+		this.mainPart = Ext.create('Ext.form.FormPanel', {
+			scrollable: null,
+			items: [{
+				xtype: 'fieldset',
+				title: Messages.LMS_ENABLE_TEXT,
+				style: {
+					textAlign: 'center'
+				},
+				items: [{
+					xtype: 'segmentedbutton',
+					style: 'margin: auto',
+					cls: 'yesnoOptions',
+					defaults: {
+						ui: 'action'
+					},
+					items: [{
+						text: Messages.YES,
+						pressed: me.getSessionInfo().courseType !== null,
+						scope: this,
+						handler: function () {
+							me.courseSelect.show();
+							if (me.courses.length !== 0) {
+								me.course = me.courses[0];
+							}
+						}
+					}, {
+						text: Messages.NO,
+						pressed: me.getSessionInfo().courseType === null,
+						scope: this,
+						handler: function () {
+							me.courseSelect.hide();
+							me.course = null;
+						}
+					}]
+				}]
+			},
+			this.courseSelect,
+			this.submitButton]
+		});
+
+		this.add([this.mainPart, this.toolbar]);
+	},
+
+	onShow: function () {
+		var me = this;
+		ARSnova.app.courseModel.getMyCourses({
+			success: function (response) {
+				me.courses = Ext.decode(response.responseText);
+				var courseArray = [];
+				var currSelected = -1;
+				me.courses.forEach(function (element, index, array) {
+					if (element.membership.userrole === "TEACHER") {
+						if (element.id === me.getSessionInfo().courseId) {
+							currSelected = index;
+						}
+						courseArray.push({
+							text: element.shortname + ": " + element.fullname,
+							value: index
+						});
+					}
+				});
+				me.courseSelect.setOptions(courseArray);
+				if (currSelected !== -1) {
+					me.course = me.courses[currSelected];
+					me.courseSelect.setValue(currSelected);
+				} else {
+					me.course = null;
+				}
+			},
+			empty: function () {
+				me.courseSelect.setOptions([]);
+			},
+			unauthenticated: function () {
+				ARSnova.app.getController('Auth').login({
+					mode: ARSnova.app.loginMode
+				});
+			},
+			failure: function () {
+				console.log("my courses request failure");
+			}
+		}, (window.innerWidth > 321 ? 'name' : 'shortname'));
+	},
+
+	transitionBackToInClassPanel: function () {
+		var sTP = ARSnova.app.mainTabPanel.tabPanel.speakerTabPanel;
+		sTP.animateActiveItem(this.getOptions().lastPanel, {
+			type: 'slide',
+			direction: 'right',
+			duration: 700,
+			listeners: {
+				scope: this,
+				animationend: function () {
+					this.destroy();
+				}
+			}
+		});
+	}
+});

--- a/src/main/webapp/app/view/speaker/AudienceQuestionPanel.js
+++ b/src/main/webapp/app/view/speaker/AudienceQuestionPanel.js
@@ -691,7 +691,7 @@ Ext.define('ARSnova.view.speaker.AudienceQuestionPanel', {
 				getAnswerCount(questionRecord, promise);
 				promises.push(promise);
 			}, this);
-		} else {
+		} else if (this.questionStore.getTotalCount() > 0) {
 			var questionRecord = this.questionStore.getAt(index);
 			var promise = new RSVP.Promise();
 			getAnswerCount(questionRecord, promise);

--- a/src/main/webapp/app/view/speaker/InClassActionButtons.js
+++ b/src/main/webapp/app/view/speaker/InClassActionButtons.js
@@ -72,6 +72,25 @@ Ext.define('ARSnova.view.speaker.InClassActionButtons', {
 			}
 		});
 
+		var me = this;
+		this.lmsChangeButton = Ext.create('ARSnova.view.MatrixButton', {
+			text: Messages.CHANGE_LMS_OPTIONS,
+			buttonConfig: 'icon',
+			cls: 'smallerActionButton',
+			imageCls: 'icon-prof',
+			scope: this,
+			handler: function () {
+				ARSnova.app.sessionModel.checkSessionLogin(sessionStorage.getItem("keyword"), {
+					success: function (session) {
+						ARSnova.app.getController('Sessions').loadLmsOptions({
+							lastPanel: me.getParent().getParent(),
+							sessionInfo: session
+						});
+					}
+				});
+			}
+		});
+
 		this.motdButton = Ext.create('ARSnova.view.MatrixButton', {
 			text: Messages.MOTD_MANAGEMENT,
 			cls: 'smallerActionButton',
@@ -118,6 +137,8 @@ Ext.define('ARSnova.view.speaker.InClassActionButtons', {
 				xtype: 'spacer'
 			}, this.motdButton, {
 				xtype: 'spacer'
+			}, this.lmsChangeButton, {
+				xtype: 'spacer'
 			}, this.sessionStatusButton, {
 				xtype: 'spacer'
 			}, this.deleteSessionButton, {
@@ -134,6 +155,8 @@ Ext.define('ARSnova.view.speaker.InClassActionButtons', {
 				flex: '3',
 				width: true
 			}, this.featureChangeEntryButton, {
+				xtype: 'spacer'
+			}, this.lmsChangeButton, {
 				xtype: 'spacer'
 			}, this.motdButton, {
 				xtype: 'spacer',


### PR DESCRIPTION
This PR, along with the backend changes (https://github.com/thm-projects/arsnova-backend/pull/41), enables a teacher to change the lms course a session is linked with. The course the session belongs to can be totally removed making it a "normal no-course-session", changed or a normal session can be "converted" into a course session. There is no limitation how often this operations can be done.
To achieve this a new button has been added to the session overview and a new panel integrated to perform the changes.
![newbutton](https://cloud.githubusercontent.com/assets/5639988/23438627/fcf43210-fe12-11e6-927c-0ba66ade3f86.PNG)
![newpanel](https://cloud.githubusercontent.com/assets/5639988/23438628/fedf2c06-fe12-11e6-8133-e4fc464c3193.PNG)
