### PR TITLE
Show Question-No. in QuestionList

### DIFF
--- a/src/main/webapp/app/view/speaker/AudienceQuestionPanel.js
+++ b/src/main/webapp/app/view/speaker/AudienceQuestionPanel.js
@@ -106,10 +106,10 @@ Ext.define('ARSnova.view.speaker.AudienceQuestionPanel', {
 
 			itemCls: 'forwardListButton',
 			itemTpl: Ext.create('Ext.XTemplate',
-				'<tpl if="!active"><div class="isInactive buttontext noOverflow">{text:htmlEncode}</div>',
+				'<tpl if="!active"><div class="isInactive buttontext noOverflow">({[this.getNumber(values)]}) {text:htmlEncode}</div>',
 				'<tpl else>',
-					'<tpl if="votingDisabled"><div class="isVoteInactive buttontext noOverflow">{text:htmlEncode}</div>',
-					'<tpl else><div class="buttontext noOverflow">{text:htmlEncode}</div></tpl>',
+					'<tpl if="votingDisabled"><div class="isVoteInactive buttontext noOverflow">({[this.getNumber(values)]}) {text:htmlEncode}</div>',
+					'<tpl else><div class="buttontext noOverflow">({[this.getNumber(values)]}) {text:htmlEncode}</div></tpl>',
 				'</tpl>',
 				'<div class="x-button x-hasbadge audiencePanelListBadge">',
 				'<tpl if="this.hasAnswers(values.numAnswers)"><span class="answersBadgeIcon badgefixed">',
@@ -130,6 +130,15 @@ Ext.define('ARSnova.view.speaker.AudienceQuestionPanel', {
 						} else {
 							return questionObj.numAnswers[0];
 						}
+					},
+
+					getNumber: function (questionObj) {
+						for (var i = 0; i < self.questionStore.data.all.length; i++) {
+							if (self.questionStore.getAt(i).data._id === questionObj._id) {
+								return i + 1;
+							}
+						}
+						return -1;
 					}
 				}
 			),
@@ -521,7 +530,6 @@ Ext.define('ARSnova.view.speaker.AudienceQuestionPanel', {
 		callback = typeof callback === 'function' ? callback : Ext.emptyFn;
 		var features = ARSnova.app.getController('Feature').getActiveFeatures();
 		var hideLoadIndicator = ARSnova.app.showLoadIndicator(Messages.LOAD_MASK, 1000);
-
 		var promise = new RSVP.Promise();
 		this.getController().getQuestions(sessionStorage.getItem('keyword'), {
 			success: Ext.bind(function (response, totalRange) {


### PR DESCRIPTION
Improves the usability for the teacher by adding the question number in front of the question. Currently there is no real association between the number shown at the top in presentation mode with which one can switch between the questions and the overview of the questions.
This also takes into account the pagination and the numbers are shown correctly when loading more questions.
![numbers](https://cloud.githubusercontent.com/assets/5639988/23438395/f4e6ff40-fe11-11e6-8166-67f67c91884a.png)
![presentation](https://cloud.githubusercontent.com/assets/5639988/23438403/f7e39f14-fe11-11e6-8535-dd0f3626b794.png)

