### PR TITLE
Fixed a bug that corrupted the download in firefox

### DIFF
--- a/src/main/webapp/app/controller/QuestionExport.js
+++ b/src/main/webapp/app/controller/QuestionExport.js
@@ -176,8 +176,8 @@ Ext.define("ARSnova.controller.QuestionExport", {
 		} else {
 			//Table header
 			exp += "\n" + Messages.ANSWERS + ";"
-				+ Messages.FIRST_ROUND + " " + Messages.GRID_LABEL_RELATIVE + ";" + Messages.FIRST_ROUND + " " + Messages.GRID_LABEL_ABSOLUTE + ";"
-				+ Messages.SECOND_ROUND + " " + Messages.GRID_LABEL_RELATIVE + ";" + Messages.SECOND_ROUND + " " + Messages.GRID_LABEL_ABSOLUTE;
+				+ Messages.FIRST_ROUND + " " + Messages.QUESTIONS_EXPORT_RELATIVE + ";" + Messages.FIRST_ROUND + Messages.QUESTIONS_EXPORT_ABSOLUTE + ";"
+				+ Messages.SECOND_ROUND + " " + Messages.QUESTIONS_EXPORT_RELATIVE + ";" + Messages.SECOND_ROUND + Messages.QUESTIONS_EXPORT_ABSOLUTE;
 			//Table contents (answers)
 			answers.each(function (record) {
 				exp += "\n" + record.get('text') + ";" + record.get('percent-round1') + ";" + record.get('value-round1') + ";" + record.get('percent-round2') + ";" + record.get('value-round2');

--- a/src/main/webapp/app/internationalization.js
+++ b/src/main/webapp/app/internationalization.js
@@ -818,6 +818,8 @@
 
 				/* content export*/
 				QUESTIONS_EXPORT_BUTTON: "Fragen<br>exportieren",
+				QUESTIONS_EXPORT_ABSOLUTE: " absolut",
+				QUESTIONS_EXPORT_RELATIVE: " relativ",
 				QUESTIONS_EXPORT_MSBOX_TITLE: "Inhalte exportieren",
 				QUESTIONS_EXPORT_MSBOX_INFO: "Die Inhalte können wahlweise als CSV-Datei oder für den Import in ARSnova-Cards als JSON-Datei exportiert werden. Fragen vom Typ \"Hot Spots\" werden übersprungen. Für den gesamten Export der Session steht der Export auf der Sessionübersichtseite zur Verfügung.",
 				QUESTIONS_CSV_EXPORT_ANSWERS_BUTTON: "Antworten<br>exportieren",
@@ -1699,6 +1701,8 @@
 
 				/* content export */
 				QUESTIONS_EXPORT_BUTTON: "Export<br>content",
+				QUESTIONS_EXPORT_ABSOLUTE: " absolute",
+				QUESTIONS_EXPORT_RELATIVE: " relative",
 				QUESTIONS_EXPORT_MSBOX_TITLE: "Export content",
 				QUESTIONS_EXPORT_MSBOX_INFO: "The content can be exported as a CSV file or preformatted for ARSnova.cards as a JSON file. \"Hot Spots\" questions won't be exported. For exporting the whole session please use the export function on the session overview.",
 				QUESTIONS_CSV_EXPORT_ANSWERS_BUTTON: "Export<br>answers",


### PR DESCRIPTION
In Firefox the file was corrupted due to the "#" symbol, this has now been fixed.