### PR TITLE
Replaced socket.io.min.js reference with socket.io.slim.min.js

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -14,7 +14,7 @@
 		<script type="text/javascript" src="splashscreen.js"></script>
 
 		<!-- Socket.IO -->
-		<script type="text/javascript" src="lib/socket.io.min.js"></script>
+		<script type="text/javascript" src="lib/socket.io.slim.min.js"></script>
 
 		<!-- QRCode -->
 		<script type="text/javascript" src="lib/qrcode.min.js"></script>


### PR DESCRIPTION
When the libraries were upgraded in this commit (https://github.com/thm-projects/arsnova-mobile/commit/b5d1c8f9d15501114ecb99e97631c170aac71a7f) this file has probably been forgotten. On our test server the error didn't show up because the old file was still present in "arsnova-mobile/src/main/webapp/build/production/ARSnova/lib" but it did on our production server.